### PR TITLE
Arch-template: Added "archlinux-virtualbox builder".

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -40,6 +40,29 @@
       "boot_command": [
         "<tab> script=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ssh.sh<enter>"
       ]
+    },
+    {
+      "name": "archlinux-virtualbox",
+      "type": "virtualbox-iso",
+      "headless": true,
+      "guest_os_type": "ArchLinux_64",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "boot_command": [
+        "<tab> script=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ssh.sh<enter>"
+      ],
+      "shutdown_command": "sudo -S poweroff",
+      "boot_wait": "12s",
+      "http_directory": "http",
+      "guest_additions_path": "VBoxGuestAdditions_{{ .Version }}.iso",
+      "virtualbox_version_file": "/home/vagrant/.vbox_version",
+      "ssh_username": "root",
+      "ssh_password": "changeme",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "3600s",
+      "ssh_pty" : "true",
+      "disk_size": 10240,
     }
   ],
   "post-processors": [


### PR DESCRIPTION
Added a builder to make the box also usable for people that use virtualbox.

It can be build using "packer build -only archlinux-virtualbox arch-template.json".

Virtualbox provides a specific type for Arch Linux:

```
vboxmanage list ostypes
...
ID:          ArchLinux
Description: Arch Linux (32-bit)
Family ID:   Linux
Family Desc: Linux
64 bit:      false

ID:          ArchLinux_64
Description: Arch Linux (64-bit)
Family ID:   Linux
Family Desc: Linux
64 bit:      true 
```

So this is defined as so:

```
"guest_os_type": "ArchLinux_64",
```
